### PR TITLE
Adding tests to steering_controllers_libray pkg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -33,13 +33,13 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.3.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: ["--line-length=99"]
@@ -52,7 +52,7 @@ repos:
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     - id: flake8
       args: ["--ignore=E501"]
@@ -119,14 +119,14 @@ repos:
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8
-    rev: v1.0.0
+    rev: v1.1.1
     hooks:
       - id: doc8
         args: ['--max-line-length=100', '--ignore=D001']
         exclude: CHANGELOG\.rst$
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
         exclude: CHANGELOG\.rst$
@@ -136,7 +136,7 @@ repos:
   # Spellcheck in comments and docs
   # skipping of *.svg files is not working...
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: ['--write-changes', '--uri-ignore-words-list=ist']

--- a/steering_controllers_library/CMakeLists.txt
+++ b/steering_controllers_library/CMakeLists.txt
@@ -64,7 +64,21 @@ install(
 )
 
 if(BUILD_TESTING)
-  # TODO
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(controller_manager REQUIRED)
+  find_package(hardware_interface REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
+
+  add_rostest_with_parameters_gmock(
+    test_steering_controllers_library test/test_steering_controllers_library.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/steering_controllers_library_params.yaml)
+  target_include_directories(test_steering_controllers_library PRIVATE include)
+  target_link_libraries(test_steering_controllers_library steering_controllers_library)
+  ament_target_dependencies(
+    test_steering_controllers_library
+    controller_interface
+    hardware_interface
+  )
 endif()
 
 ament_export_include_directories(

--- a/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
@@ -76,7 +76,8 @@ public:
     const rclcpp_lifecycle::State & previous_state) override;
 
   STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::return_type
-  update_reference_from_subscribers(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+  update_reference_from_subscribers(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
   STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::return_type
   update_and_write_commands(const rclcpp::Time & time, const rclcpp::Duration & period) override;

--- a/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_controllers_library.hpp
@@ -76,7 +76,7 @@ public:
     const rclcpp_lifecycle::State & previous_state) override;
 
   STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::return_type
-  update_reference_from_subscribers() override;
+  update_reference_from_subscribers(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
   STEERING_CONTROLLERS__VISIBILITY_PUBLIC controller_interface::return_type
   update_and_write_commands(const rclcpp::Time & time, const rclcpp::Duration & period) override;

--- a/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
+++ b/steering_controllers_library/include/steering_controllers_library/steering_odometry.hpp
@@ -250,7 +250,7 @@ private:
   double traction_wheel_old_pos_;
   double traction_right_wheel_old_pos_;
   double traction_left_wheel_old_pos_;
-  /// Rolling mean accumulators for the linar and angular velocities:
+  /// Rolling mean accumulators for the linear and angular velocities:
   size_t velocity_rolling_window_size_;
   rcpputils::RollingMeanAccumulator<double> linear_acc_;
   rcpputils::RollingMeanAccumulator<double> angular_acc_;

--- a/steering_controllers_library/package.xml
+++ b/steering_controllers_library/package.xml
@@ -14,6 +14,8 @@
   <author email="tomislav.petkovic.fer@gmail.com">dr. sc. Tomislav Petkovic</author>
   <author email="tony.najjar@logivations.com">Tony Najjar</author>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>generate_parameter_library</build_depend>
 
   <depend>control_msgs</depend>

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -411,7 +411,8 @@ controller_interface::CallbackReturn SteeringControllersLibrary::on_deactivate(
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type SteeringControllersLibrary::update_reference_from_subscribers(const rclcpp::Time & time, const rclcpp::Duration & period)
+controller_interface::return_type SteeringControllersLibrary::update_reference_from_subscribers(
+  const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   auto current_ref = *(input_ref_.readFromRT());
   const auto age_of_last_command = time - (current_ref)->header.stamp;
@@ -429,20 +430,20 @@ controller_interface::return_type SteeringControllersLibrary::update_reference_f
   {
     if (!std::isnan(current_ref->twist.linear.x) && !std::isnan(current_ref->twist.angular.z))
     {
-      if(params_.position_feedback == false)
+      if (params_.position_feedback == false)
       {
         reference_interfaces_[0] = 0.0;
         reference_interfaces_[1] = 0.0;
         current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
-        current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();  
-      } else 
+        current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
+      }
+      else
       {
         reference_interfaces_[0] = std::numeric_limits<double>::quiet_NaN();
         reference_interfaces_[1] = std::numeric_limits<double>::quiet_NaN();
         current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
         current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
-      } 
-
+      }
     }
   }
 
@@ -495,24 +496,24 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
           }
         }
       }
-    } 
+    }
   }
   else
   {
-      reference_interfaces_[0] = std::numeric_limits<double>::quiet_NaN();
-      reference_interfaces_[1] = std::numeric_limits<double>::quiet_NaN();
+    reference_interfaces_[0] = std::numeric_limits<double>::quiet_NaN();
+    reference_interfaces_[1] = std::numeric_limits<double>::quiet_NaN();
 
-      for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
-      {
-        command_interfaces_[i].set_value(0.0);
-      }
-      for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
-      {
-        command_interfaces_[i + params_.rear_wheels_names.size()].set_value(0.0);
-      }
+    for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
+    {
+      command_interfaces_[i].set_value(0.0);
+    }
+    for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
+    {
+      command_interfaces_[i + params_.rear_wheels_names.size()].set_value(0.0);
+    }
 
-      current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
-      current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
+    current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
+    current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
   }
 
   // Publish odometry message

--- a/steering_controllers_library/src/steering_controllers_library.cpp
+++ b/steering_controllers_library/src/steering_controllers_library.cpp
@@ -411,10 +411,10 @@ controller_interface::CallbackReturn SteeringControllersLibrary::on_deactivate(
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type SteeringControllersLibrary::update_reference_from_subscribers()
+controller_interface::return_type SteeringControllersLibrary::update_reference_from_subscribers(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   auto current_ref = *(input_ref_.readFromRT());
-  const auto age_of_last_command = get_node()->now() - (current_ref)->header.stamp;
+  const auto age_of_last_command = time - (current_ref)->header.stamp;
 
   // send message only if there is no timeout
   if (age_of_last_command <= ref_timeout_ || ref_timeout_ == rclcpp::Duration::from_seconds(0))
@@ -429,10 +429,20 @@ controller_interface::return_type SteeringControllersLibrary::update_reference_f
   {
     if (!std::isnan(current_ref->twist.linear.x) && !std::isnan(current_ref->twist.angular.z))
     {
-      reference_interfaces_[0] = 0.0;
-      reference_interfaces_[1] = 0.0;
-      current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
-      current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
+      if(params_.position_feedback == false)
+      {
+        reference_interfaces_[0] = 0.0;
+        reference_interfaces_[1] = 0.0;
+        current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
+        current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();  
+      } else 
+      {
+        reference_interfaces_[0] = std::numeric_limits<double>::quiet_NaN();
+        reference_interfaces_[1] = std::numeric_limits<double>::quiet_NaN();
+        current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
+        current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
+      } 
+
     }
   }
 
@@ -449,38 +459,60 @@ controller_interface::return_type SteeringControllersLibrary::update_and_write_c
   // Limit velocities and accelerations:
   // TODO(destogl): add limiter for the velocities
 
-  if (!std::isnan(reference_interfaces_[0]) && !std::isnan(reference_interfaces_[1]))
+  auto current_ref = *(input_ref_.readFromRT());
+  const auto age_of_last_command = time - current_ref->header.stamp;
+  if (age_of_last_command <= ref_timeout_ || ref_timeout_ == rclcpp::Duration::from_seconds(0))
   {
-    // store and set commands
-    const double linear_command = reference_interfaces_[0];
-    const double angular_command = reference_interfaces_[1];
-    auto [traction_commands, steering_commands] =
-      odometry_.get_commands(linear_command, angular_command);
-    if (params_.front_steering)
+    if (!std::isnan(reference_interfaces_[0]) && !std::isnan(reference_interfaces_[1]))
     {
-      for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
+      // store and set commands
+      const double linear_command = reference_interfaces_[0];
+      const double angular_command = reference_interfaces_[1];
+      auto [traction_commands, steering_commands] =
+        odometry_.get_commands(linear_command, angular_command);
+      if (params_.front_steering)
       {
-        command_interfaces_[i].set_value(traction_commands[i]);
-      }
-      for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
-      {
-        command_interfaces_[i + params_.rear_wheels_names.size()].set_value(steering_commands[i]);
-      }
-    }
-    else
-    {
-      {
-        for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
+        for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
         {
           command_interfaces_[i].set_value(traction_commands[i]);
         }
-        for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
+        for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
         {
-          command_interfaces_[i + params_.front_wheels_names.size()].set_value(
-            steering_commands[i]);
+          command_interfaces_[i + params_.rear_wheels_names.size()].set_value(steering_commands[i]);
         }
       }
-    }
+      else
+      {
+        {
+          for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
+          {
+            command_interfaces_[i].set_value(traction_commands[i]);
+          }
+          for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
+          {
+            command_interfaces_[i + params_.front_wheels_names.size()].set_value(
+              steering_commands[i]);
+          }
+        }
+      }
+    } 
+  }
+  else
+  {
+      reference_interfaces_[0] = std::numeric_limits<double>::quiet_NaN();
+      reference_interfaces_[1] = std::numeric_limits<double>::quiet_NaN();
+
+      for (size_t i = 0; i < params_.rear_wheels_names.size(); i++)
+      {
+        command_interfaces_[i].set_value(0.0);
+      }
+      for (size_t i = 0; i < params_.front_wheels_names.size(); i++)
+      {
+        command_interfaces_[i + params_.rear_wheels_names.size()].set_value(0.0);
+      }
+
+      current_ref->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
+      current_ref->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
   }
 
   // Publish odometry message

--- a/steering_controllers_library/test/steering_controllers_library_params.yaml
+++ b/steering_controllers_library/test/steering_controllers_library_params.yaml
@@ -1,0 +1,17 @@
+test_steering_controllers_library:
+  ros__parameters:
+
+    reference_timeout: 0.1
+    front_steering: true
+    open_loop: false
+    velocity_rolling_window_size: 10
+    position_feedback: false
+    use_stamped_vel: true
+    rear_wheels_names: [rear_right_wheel_joint, rear_left_wheel_joint]
+    front_wheels_names: [front_right_steering_joint, front_left_steering_joint]
+
+    wheelbase: 3.24644
+    front_wheel_track: 2.12321
+    rear_wheel_track: 1.76868
+    front_wheels_radius: 0.45
+    rear_wheels_radius: 0.45

--- a/steering_controllers_library/test/test_steering_controllers_library.cpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2022, Stogl Robotics Consulting UG (haftungsbeschränkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_steering_controllers_library.hpp"
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+class SteeringControllersLibraryTest
+: public SteeringControllersLibraryFixture<TestableSteeringControllersLibrary>
+{
+};
+
+// Tests controller behavior when too old msg is sent / age_of_last_command > ref_timeout case
+TEST_F(SteeringControllersLibraryTest, test_update_logic_not_chainable)
+{
+  // 1. age>ref_timeout 2. age<ref_timeout
+  SetUpController();
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  controller_->set_chained_mode(false);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_FALSE(controller_->is_in_chained_mode());
+
+  for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+
+  // set command statically
+  joint_command_values_[1] = command_lin_x;
+
+  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
+
+  msg->header.stamp = controller_->get_node()->now() - controller_->ref_timeout_ -
+                      rclcpp::Duration::from_seconds(0.1);
+  msg->twist.linear.x = TEST_LINEAR_VELOCITY_X;
+  msg->twist.linear.y = TEST_LINEAR_VELOCITY_y;
+  msg->twist.linear.z = std::numeric_limits<double>::quiet_NaN();
+  msg->twist.angular.x = std::numeric_limits<double>::quiet_NaN();
+  msg->twist.angular.y = std::numeric_limits<double>::quiet_NaN();
+  msg->twist.angular.z = TEST_ANGULAR_VELOCITY_Z;
+  controller_->input_ref_.writeFromNonRT(msg);
+  const auto age_of_last_command =
+    controller_->get_node()->now() - (*(controller_->input_ref_.readFromNonRT()))->header.stamp;
+
+  // age_of_last_command > ref_timeout_
+  ASSERT_FALSE(age_of_last_command <= controller_->ref_timeout_);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->twist.linear.x, TEST_LINEAR_VELOCITY_X);
+  ASSERT_EQ(
+    controller_->update_reference_from_subscribers(
+      controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  EXPECT_EQ(controller_->reference_interfaces_[1], 0);
+  for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_FALSE(std::isnan(interface));
+  }
+
+  ASSERT_EQ(
+    controller_->update_and_write_commands(
+      controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  EXPECT_TRUE(std::isnan(controller_->reference_interfaces_[0]));
+
+  EXPECT_EQ(joint_command_values_[1], 0);
+  for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+  for (size_t i = 0; i < controller_->command_interfaces_.size(); ++i)
+  {
+    EXPECT_EQ(controller_->command_interfaces_[i].get_value(), 0.0);
+  }
+
+  std::shared_ptr<ControllerReferenceMsg> msg_2 = std::make_shared<ControllerReferenceMsg>();
+  msg_2->header.stamp = controller_->get_node()->now() - rclcpp::Duration::from_seconds(0.01);
+  msg_2->twist.linear.x = TEST_LINEAR_VELOCITY_X;
+  msg_2->twist.linear.y = TEST_LINEAR_VELOCITY_y;
+  msg_2->twist.linear.z = std::numeric_limits<double>::quiet_NaN();
+  msg_2->twist.angular.x = std::numeric_limits<double>::quiet_NaN();
+  msg_2->twist.angular.y = std::numeric_limits<double>::quiet_NaN();
+  msg_2->twist.angular.z = TEST_ANGULAR_VELOCITY_Z;
+  controller_->input_ref_.writeFromNonRT(msg_2);
+  const auto age_of_last_command_2 =
+    controller_->get_node()->now() - (*(controller_->input_ref_.readFromNonRT()))->header.stamp;
+
+  // age_of_last_command_2 < ref_timeout_
+  ASSERT_TRUE(age_of_last_command_2 <= controller_->ref_timeout_);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->twist.linear.x, TEST_LINEAR_VELOCITY_X);
+  ASSERT_EQ(
+    controller_->update_reference_from_subscribers(
+      controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+  ASSERT_EQ(
+    controller_->update_and_write_commands(
+      controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  EXPECT_NE(joint_command_values_[1], command_lin_x);
+  //  w0_vel = 1.0 / params_.kinematics.wheels_radius * (body_velocity_center_frame_.linear_x - body_velocity_center_frame_.linear_y - params_.kinematics.wheels_k * body_velocity_center_frame_.angular_z);
+  //  joint_command_values_[1] = 1.0 / 0.5 * (1.5 - 0.0 - 1 * 0.0)
+  EXPECT_EQ(joint_command_values_[1], 3.0);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->twist.linear.x, TEST_LINEAR_VELOCITY_X);
+  for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_FALSE(std::isnan(interface));
+  }
+  for (size_t i = 0; i < controller_->command_interfaces_.size(); ++i)
+  {
+    EXPECT_EQ(controller_->command_interfaces_[i].get_value(), 3.0);
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/steering_controllers_library/test/test_steering_controllers_library.hpp
+++ b/steering_controllers_library/test/test_steering_controllers_library.hpp
@@ -1,0 +1,316 @@
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_STEERING_CONTROLLERS_LIBRARY_HPP_
+#define TEST_STEERING_CONTROLLERS_LIBRARY_HPP_
+
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "steering_controllers_library/steering_controllers_library.hpp"
+#include "gmock/gmock.h"
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/parameter_value.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp/utilities.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+using ControllerStateMsg =
+  steering_controllers_library::SteeringControllersLibrary::AckermanControllerState;
+using ControllerReferenceMsg =
+  steering_controllers_library::SteeringControllersLibrary::ControllerTwistReferenceMsg;
+
+// name constants for state interfaces
+using steering_controllers_library::STATE_STEER_LEFT_WHEEL;
+using steering_controllers_library::STATE_STEER_RIGHT_WHEEL;
+using steering_controllers_library::STATE_TRACTION_LEFT_WHEEL;
+using steering_controllers_library::STATE_TRACTION_RIGHT_WHEEL;
+
+// name constants for command interfaces
+using steering_controllers_library::CMD_STEER_LEFT_WHEEL;
+using steering_controllers_library::CMD_STEER_RIGHT_WHEEL;
+using steering_controllers_library::CMD_TRACTION_LEFT_WHEEL;
+using steering_controllers_library::CMD_TRACTION_RIGHT_WHEEL;
+
+namespace
+{
+constexpr auto NODE_SUCCESS = controller_interface::CallbackReturn::SUCCESS;
+constexpr auto NODE_ERROR = controller_interface::CallbackReturn::ERROR;
+const double COMMON_THRESHOLD = 1e-6;
+}  // namespace
+// namespace
+
+// subclassing and friending so we can access member variables
+class TestableSteeringControllersLibrary
+: public steering_controllers_library::SteeringControllersLibrary
+{
+  FRIEND_TEST(SteeringControllersLibraryTest, test_update_logic_not_chainable);
+
+
+public:
+  controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override
+  {
+    auto ret =
+      steering_controllers_library::SteeringControllersLibrary::on_configure(previous_state);
+    // Only if on_configure is successful create subscription
+    if (ret == CallbackReturn::SUCCESS)
+    {
+      ref_subscriber_wait_set_.add_subscription(ref_subscriber_twist_);
+    }
+    return ret;
+  }
+
+  controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & previous_state) override
+  {
+    auto ref_itfs = on_export_reference_interfaces();
+    return steering_controllers_library::SteeringControllersLibrary::on_activate(previous_state);
+  }
+
+  /**
+   * @brief wait_for_command blocks until a new ControllerReferenceMsg is received.
+   * Requires that the executor is not spinned elsewhere between the
+   *  message publication and the call to this function.
+   *
+   * @return true if new ControllerReferenceMsg msg was received, false if timeout.
+   */
+  bool wait_for_command(
+    rclcpp::Executor & executor, rclcpp::WaitSet & subscriber_wait_set,
+    const std::chrono::milliseconds & timeout = std::chrono::milliseconds{500})
+  {
+    bool success = subscriber_wait_set.wait(timeout).kind() == rclcpp::WaitResultKind::Ready;
+    if (success)
+    {
+      executor.spin_some();
+    }
+    return success;
+  }
+
+  bool wait_for_commands(
+    rclcpp::Executor & executor,
+    const std::chrono::milliseconds & timeout = std::chrono::milliseconds{500})
+  {
+    return wait_for_command(executor, ref_subscriber_wait_set_, timeout);
+  }
+
+private:
+  rclcpp::WaitSet ref_subscriber_wait_set_;
+};
+
+// We are using template class here for easier reuse of Fixture in specializations of controllers
+template <typename CtrlType>
+class SteeringControllersLibraryFixture : public ::testing::Test
+{
+public:
+  static void SetUpTestCase() {}
+
+  void SetUp()
+  {
+    // initialize controller
+    controller_ = std::make_unique<CtrlType>();
+
+    command_publisher_node_ = std::make_shared<rclcpp::Node>("command_publisher");
+    command_publisher_ = command_publisher_node_->create_publisher<ControllerReferenceMsg>(
+      "/test_steering_controllers_library/reference", rclcpp::SystemDefaultsQoS());
+  }
+
+  static void TearDownTestCase() {}
+
+  void TearDown() { controller_.reset(nullptr); }
+
+protected:
+  void SetUpController(const std::string controller_name = "test_steering_controllers_library")
+  {
+    ASSERT_EQ(controller_->init(controller_name), controller_interface::return_type::OK);
+
+    if (position_feedback_ == true)
+    {
+      traction_interface_name_ = "position";
+    }
+    else
+    {
+      traction_interface_name_ = "velocity";
+    }
+
+    std::vector<hardware_interface::LoanedCommandInterface> command_ifs;
+    command_itfs_.reserve(joint_command_values_.size());
+    command_ifs.reserve(joint_command_values_.size());
+
+    command_itfs_.emplace_back(hardware_interface::CommandInterface(
+      rear_wheels_names_[0], traction_interface_name_,
+      &joint_command_values_[CMD_TRACTION_RIGHT_WHEEL]));
+    command_ifs.emplace_back(command_itfs_.back());
+
+    command_itfs_.emplace_back(hardware_interface::CommandInterface(
+      rear_wheels_names_[1], steering_interface_name_,
+      &joint_command_values_[CMD_TRACTION_LEFT_WHEEL]));
+    command_ifs.emplace_back(command_itfs_.back());
+
+    command_itfs_.emplace_back(hardware_interface::CommandInterface(
+      front_wheels_names_[0], steering_interface_name_,
+      &joint_command_values_[CMD_STEER_RIGHT_WHEEL]));
+    command_ifs.emplace_back(command_itfs_.back());
+
+    command_itfs_.emplace_back(hardware_interface::CommandInterface(
+      front_wheels_names_[1], steering_interface_name_,
+      &joint_command_values_[CMD_STEER_LEFT_WHEEL]));
+    command_ifs.emplace_back(command_itfs_.back());
+
+    std::vector<hardware_interface::LoanedStateInterface> state_ifs;
+    state_itfs_.reserve(joint_state_values_.size());
+    state_ifs.reserve(joint_state_values_.size());
+
+    state_itfs_.emplace_back(hardware_interface::StateInterface(
+      rear_wheels_names_[0], traction_interface_name_,
+      &joint_state_values_[STATE_TRACTION_RIGHT_WHEEL]));
+    state_ifs.emplace_back(state_itfs_.back());
+
+    state_itfs_.emplace_back(hardware_interface::StateInterface(
+      rear_wheels_names_[1], traction_interface_name_,
+      &joint_state_values_[STATE_TRACTION_LEFT_WHEEL]));
+    state_ifs.emplace_back(state_itfs_.back());
+
+    state_itfs_.emplace_back(hardware_interface::StateInterface(
+      front_wheels_names_[0], steering_interface_name_,
+      &joint_state_values_[STATE_STEER_RIGHT_WHEEL]));
+    state_ifs.emplace_back(state_itfs_.back());
+
+    state_itfs_.emplace_back(hardware_interface::StateInterface(
+      front_wheels_names_[1], steering_interface_name_,
+      &joint_state_values_[STATE_STEER_LEFT_WHEEL]));
+    state_ifs.emplace_back(state_itfs_.back());
+
+    controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
+  }
+
+  void subscribe_and_get_messages(ControllerStateMsg & msg)
+  {
+    // create a new subscriber
+    rclcpp::Node test_subscription_node("test_subscription_node");
+    auto subs_callback = [&](const ControllerStateMsg::SharedPtr) {};
+    auto subscription = test_subscription_node.create_subscription<ControllerStateMsg>(
+      "/test_steering_controllers_library/controller_state", 10, subs_callback);
+
+    // call update to publish the test value
+    ASSERT_EQ(
+      controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+      controller_interface::return_type::OK);
+
+    // call update to publish the test value
+    // since update doesn't guarantee a published message, republish until received
+    int max_sub_check_loop_count = 5;  // max number of tries for pub/sub loop
+    rclcpp::WaitSet wait_set;          // block used to wait on message
+    wait_set.add_subscription(subscription);
+    while (max_sub_check_loop_count--)
+    {
+      controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01));
+      // check if message has been received
+      if (wait_set.wait(std::chrono::milliseconds(2)).kind() == rclcpp::WaitResultKind::Ready)
+      {
+        break;
+      }
+    }
+    ASSERT_GE(max_sub_check_loop_count, 0) << "Test was unable to publish a message through "
+                                              "controller/broadcaster update loop";
+
+    // take message from subscription
+    rclcpp::MessageInfo msg_info;
+    ASSERT_TRUE(subscription->take(msg, msg_info));
+  }
+
+  void publish_commands(const double linear = 0.1, const double angular = 0.2)
+  {
+    auto wait_for_topic = [&](const auto topic_name)
+    {
+      size_t wait_count = 0;
+      while (command_publisher_node_->count_subscribers(topic_name) == 0)
+      {
+        if (wait_count >= 5)
+        {
+          auto error_msg =
+            std::string("publishing to ") + topic_name + " but no node subscribes to it";
+          throw std::runtime_error(error_msg);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ++wait_count;
+      }
+    };
+
+    wait_for_topic(command_publisher_->get_topic_name());
+
+    ControllerReferenceMsg msg;
+    msg.twist.linear.x = linear;
+    msg.twist.angular.z = angular;
+
+    command_publisher_->publish(msg);
+  }
+
+protected:
+  // Controller-related parameters
+  double reference_timeout_ = 2.0;
+  bool front_steering_ = true;
+  bool open_loop_ = false;
+  unsigned int velocity_rolling_window_size_ = 10;
+  bool position_feedback_ = false;
+  bool use_stamped_vel_ = true;
+  std::vector<std::string> rear_wheels_names_ = {"rear_right_wheel_joint", "rear_left_wheel_joint"};
+  std::vector<std::string> front_wheels_names_ = {
+    "front_right_steering_joint", "front_left_steering_joint"};
+  std::vector<std::string> joint_names_ = {
+    rear_wheels_names_[0], rear_wheels_names_[1], front_wheels_names_[0], front_wheels_names_[1]};
+
+  std::vector<std::string> rear_wheels_preceeding_names_ = {
+    "pid_controller/rear_right_wheel_joint", "pid_controller/rear_left_wheel_joint"};
+  std::vector<std::string> front_wheels_preceeding_names_ = {
+    "pid_controller/front_right_steering_joint", "pid_controller/front_left_steering_joint"};
+  std::vector<std::string> preceeding_joint_names_ = {
+    rear_wheels_preceeding_names_[0], rear_wheels_preceeding_names_[1],
+    front_wheels_preceeding_names_[0], front_wheels_preceeding_names_[1]};
+
+  double wheelbase_ = 3.24644;
+  double front_wheel_track_ = 2.12321;
+  double rear_wheel_track_ = 1.76868;
+  double front_wheels_radius_ = 0.45;
+  double rear_wheels_radius_ = 0.45;
+
+  std::array<double, 4> joint_state_values_ = {0.5, 0.5, 0.0, 0.0};
+  std::array<double, 4> joint_command_values_ = {1.1, 3.3, 2.2, 4.4};
+  static constexpr double TEST_LINEAR_VELOCITY_X = 1.5;
+  static constexpr double TEST_LINEAR_VELOCITY_y = 0.0;
+  static constexpr double TEST_ANGULAR_VELOCITY_Z = 0.0;
+  double command_lin_x = 111;
+  std::array<std::string, 2> joint_reference_interfaces_ = {"linear/velocity", "angular/position"};
+  std::string steering_interface_name_ = "position";
+  // defined in setup
+  std::string traction_interface_name_ = "";
+  std::string preceeding_prefix_ = "pid_controller";
+
+  std::vector<hardware_interface::StateInterface> state_itfs_;
+  std::vector<hardware_interface::CommandInterface> command_itfs_;
+
+  // Test related parameters
+  std::unique_ptr<TestableSteeringControllersLibrary> controller_;
+  rclcpp::Node::SharedPtr command_publisher_node_;
+  rclcpp::Publisher<ControllerReferenceMsg>::SharedPtr command_publisher_;
+};
+
+#endif  // TEST_STEERING_CONTROLLERS_LIBRARY_HPP_


### PR DESCRIPTION
in test header file it is declared that the added tests for steering_controllers_libraya assume the ackerman vehicle configuration and hence the state, comand and reference interfaces of the ackerman vehicle 4W configuration.
added two tests, that check exported interfaces and update logic for cases position_feedback = false/true