### PR TITLE
Odometry Position Frame

### DIFF
--- a/mecanum_drive_controller/package.xml
+++ b/mecanum_drive_controller/package.xml
@@ -35,6 +35,7 @@
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>
+  <test_depend>hardware_interface_testing</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>
 
   <export>

--- a/mecanum_drive_controller/src/odometry.cpp
+++ b/mecanum_drive_controller/src/odometry.cpp
@@ -101,7 +101,7 @@ bool Odometry::update(
   orientation_z_in_base_frame_ += velocity_in_base_frame_angular_z * dt;
 
   tf2::Quaternion orientation_R_b_odom;
-  orientation_R_b_odom.setRPY(0.0, 0.0, -base_frame_offset_[2]);
+  orientation_R_b_odom.setRPY(0.0, 0.0, orientation_z_in_base_frame_);
 
   tf2::Matrix3x3 angular_transformation_from_base_2_odom = tf2::Matrix3x3((orientation_R_b_odom));
   tf2::Vector3 velocity_in_base_frame_w_r_t_odom_frame_ =


### PR DESCRIPTION
Odometry position is not being transformed to the odometry frame. Therefore, when using an external odom TF pubisher, i.e. using the `ekf_localization_node`, the resulting frame appears as if twist commands were being sent in the odom frame instead of the base frame. 

For example, see the simulated mecanum robot below. 
![odom_orig](https://github.com/user-attachments/assets/23e48046-9390-4730-a78e-56b76af603a2)

If instead the integrated orientation is used to determine the position of the robot, we have the following: 
![odom_change](https://github.com/user-attachments/assets/c91a53a1-3ef3-4b45-bda2-c6c6b9aadbc8)

I have also added the `hardware_interface_testing`  to the `package.xml` as it is utilized but not set as a dependency. 